### PR TITLE
[MT-1466] - 1.2.0 - trackThirdPartySharing fix

### DIFF
--- a/adjust/build.gradle
+++ b/adjust/build.gradle
@@ -8,12 +8,11 @@ group = 'com.tealium.remotecommands'
 version = tealium_adjust_version
 
 android {
-    compileSdkVersion 32
-    buildToolsVersion "30.0.3"
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -34,6 +33,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.tealium.remotecommands.adjust'
 }
 
 dependencies {
@@ -47,7 +47,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.+'
     testImplementation 'io.mockk:mockk:1.12.0'
-    testImplementation "org.robolectric:robolectric:4.6.1"
+    testImplementation "org.robolectric:robolectric:4.11.1"
 }
 
 afterEvaluate {

--- a/adjust/src/main/AndroidManifest.xml
+++ b/adjust/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.tealium.remotecommands.adjust">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/adjust/src/main/java/com/tealium/remotecommands/adjust/AdjustInstance.kt
+++ b/adjust/src/main/java/com/tealium/remotecommands/adjust/AdjustInstance.kt
@@ -231,14 +231,10 @@ class AdjustInstance(
     }
 
     override fun setThirdPartySharing(enabled: Boolean) {
-        if (!enabled) {
-            Adjust.disableThirdPartySharing(application)
-        } else {
-            val sharing = AdjustThirdPartySharing(true)
-            //  sharing.addGranularOption()
-            // TODO (how best to map granular options)
-            Adjust.trackThirdPartySharing(sharing)
-        }
+        val sharing = AdjustThirdPartySharing(enabled)
+        //  sharing.addGranularOption()
+        // TODO (how best to map granular options)
+        Adjust.trackThirdPartySharing(sharing)
     }
 
     override fun trackMeasurementConsent(consented: Boolean) {

--- a/adjust/src/test/java/com/tealium/remotecommands/adjust/AdjustCommandTests.kt
+++ b/adjust/src/test/java/com/tealium/remotecommands/adjust/AdjustCommandTests.kt
@@ -313,7 +313,9 @@ class AdjustCommandTests {
         adjustCommand.setThirdPartySharing(false)
 
         verifyOrder {
-            Adjust.disableThirdPartySharing(mockApp)
+            Adjust.trackThirdPartySharing(match {
+                it.enabled == false
+            })
         }
     }
 
@@ -324,7 +326,9 @@ class AdjustCommandTests {
         adjustCommand.setThirdPartySharing(true)
 
         verifyOrder {
-            Adjust.trackThirdPartySharing(any())
+            Adjust.trackThirdPartySharing(match {
+                it.enabled == true
+            })
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
-    buildToolsVersion "30.0.3"
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         buildConfigField 'String', 'TAG', "\"App\""
@@ -35,6 +34,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.tealium.example'
 }
 
 dependencies {
@@ -48,9 +48,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.2'
     testImplementation 'junit:junit:4.+'
 
-    implementation "com.tealium:kotlin-core:1.4.0"
-    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.1.1"
-    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.1.2" // optional for tag management RCs
+    implementation "com.tealium:kotlin-core:1.5.5"
+    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.3.1"
+    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.2.1" // optional for tag management RCs
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation project(":adjust")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.tealium.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name=".App"

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.30"
-    ext.tealium_adjust_version = "1.1.0"
+    ext.kotlin_version = "1.8.22"
+    ext.tealium_adjust_version = "1.2.0"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
 - Fix: `trackThirdPartySharing` updated to match iOS implementation;  removed `disableThirdPartySharing`
 - Various dependency updates
   - Kotlin 1.8.22
   - AGP 7.4.2
   - Android Target + Compile SDK 33
   - Robolectric 4.11.2